### PR TITLE
chore: Bump zola-devin theme to 32f0a7f

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ $RECYCLE.BIN/
 # Mac
 .DS_Store
 
+# LLM
+.claude/
+
 # Zola
 public/ 
 static/processed_images/


### PR DESCRIPTION
Theme update brings Mermaid diagram rendering (auto-detects fenced
```mermaid blocks, no shortcode required) and a canonical link tag in
base.html. Also ignore the local .claude/ workspace directory.